### PR TITLE
Rollback bootstrap_sass from 3.4.1 to 3.3.7 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'font-awesome-rails'
 
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
-gem 'bootstrap-sass'
+gem 'bootstrap-sass', '~> 3.3.3'
 gem 'email_validator'
 gem 'kaminari'
 gem 'bootstrap-kaminari-views'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,9 +86,9 @@ GEM
     bootstrap-kaminari-views (0.0.5)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    bootstrap-sass (3.4.1)
+    bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
+      sass (>= 3.3.4)
     brakeman (4.3.1)
     builder (3.2.3)
     bullet (4.14.7)
@@ -336,8 +336,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.2.1)
-      ffi (~> 1.9)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     sidekiq (4.0.2)
@@ -403,7 +401,7 @@ DEPENDENCIES
   aws-sdk-s3
   bcrypt (~> 3.1.7)
   bootstrap-kaminari-views
-  bootstrap-sass
+  bootstrap-sass (~> 3.3.3)
   brakeman
   bullet
   bundler-audit


### PR DESCRIPTION
Rollback bootstrap_sass gem version from 3.4.1 to 3.3.7 caused by production server GCC compiler version incompatible